### PR TITLE
Add PT-BR course plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ PraisonAI is a production-ready Multi-AI Agents framework with self-reflection, 
   </a>
 </div>
 
+Para documentação em Português, acesse [docs/pt-br/README.md](docs/pt-br/README.md).
+
 ## Key Features
 
 - 🤖 Automated AI Agents Creation

--- a/docs/pt-br/00_introducao/00_como_usar_esta_documentacao.md
+++ b/docs/pt-br/00_introducao/00_como_usar_esta_documentacao.md
@@ -4,7 +4,9 @@ Esta documentação foi pensada para ser um recurso completo para o seu aprendiz
 
 ## Navegação
 
-A estrutura de pastas foi organizada em módulos sequenciais. Recomendamos seguir a ordem para um aprendizado progressivo. Utilize os links internos para navegar entre os tópicos relacionados e construir um mapa mental dos conceitos.
+A estrutura de pastas foi organizada em módulos sequenciais. Recomendamos seguir a ordem para um aprendizado progressivo. Utilize os links internos para navegar entre os tópicos relacionados e construir um mapa mental dos conceitos. Para entender como aproveitar melhor cada módulo, consulte também a seção [Metodologia de Aprendizado](03_metodologia_de_aprendizado.md).
+Para ver um exemplo completo e rápido de configuração de agentes, consulte [Criando Seu Primeiro Agente](../03_usando_praisonai/04_criando_seu_primeiro_agente.md). Para conhecer os diferentes [Modelos de Agentes](../03_usando_praisonai/05_modelos_de_agentes.md) disponíveis, acesse a seção dedicada.
+Caso surjam dúvidas durante seus testes, consulte também a [Dúvidas Frequentes](../09_duvidas_frequentes.md).
 
 ## Plugins Obsidian Sugeridos
 

--- a/docs/pt-br/00_introducao/03_metodologia_de_aprendizado.md
+++ b/docs/pt-br/00_introducao/03_metodologia_de_aprendizado.md
@@ -1,0 +1,33 @@
+# Metodologia de Aprendizado
+
+Este curso foi estruturado com base em princípios de ensino científico para que você progrida de forma gradual e tenha segurança ao aplicar o PraisonAI na prática.
+
+## 1. Ciclo de Aprendizado
+
+1. **Apresentação do Conceito**
+   - Cada módulo inicia com uma breve exposição teórica do tema.
+2. **Exemplos Guiados**
+   - Em seguida você encontra exemplos completos para reproduzir no terminal ou em seu editor.
+3. **Prática Ativa**
+   - É recomendável digitar os comandos manualmente para reforçar a memorização.
+4. **Reflexão e Revisão**
+   - Ao final de cada seção, revise o que funcionou e anote dúvidas antes de prosseguir.
+
+> [!TIP]
+> Use a técnica de Feynman: tente explicar o assunto com suas próprias palavras a outra pessoa ou em notas. Se travar em alguma parte, retorne à documentação e revise.
+
+## 2. Ambiente de Estudos
+
+- Organize uma pasta dedicada para testar os exemplos.
+- Mantenha um terminal aberto para executar os comandos passo a passo.
+- Utilize o Obsidian ou outro editor Markdown para registrar suas observações.
+
+## 3. Aprofundamento Progressivo
+
+A documentação foi pensada para que cada módulo dependa do anterior. Se algum conceito ainda não estiver claro, volte ao módulo correspondente e refaça os exercícios. Essa repetição espaçada ajuda na fixação a longo prazo.
+
+## Próximos Passos
+
+Após dominar esta metodologia, avance para o módulo de **Instalação** e siga a sequência sugerida no README principal.
+
+Bom estudo!

--- a/docs/pt-br/03_usando_praisonai/01_usando_com_python.md
+++ b/docs/pt-br/03_usando_praisonai/01_usando_com_python.md
@@ -139,11 +139,12 @@ O diretório `examples/python/` no repositório PraisonAI é rico em exemplos qu
     *   `example_custom_tools.py`: Como definir e usar ferramentas personalizadas.
     *   `memory_example.py` e `memory_simple.py`: Uso de memória.
     *   `workflow_example_basic.py` e `workflow_example_detailed.py`: Definição de workflows de agentes.
-*   **`examples/python/agents/`**: Diferentes tipos de agentes especializados.
+*   **`examples/python/agents/`**: Diferentes tipos de agentes especializados. Consulte [Modelos de Agentes](05_modelos_de_agentes.md) para um resumo de cada um.
 *   **`examples/python/concepts/`**: Implementações de RAG, processamento de CSV, etc.
 *   **`examples/python/usecases/`**: Soluções para casos de uso específicos como análise de sentimentos, revisão de código, etc.
 
 **Recomendação:**
 Clone o repositório PraisonAI (`git clone https://github.com/MervinPraison/PraisonAI.git`) e explore esses exemplos. Modifique-os, execute-os e veja como diferentes configurações afetam o comportamento dos agentes. Esta é uma das melhores maneiras de aprofundar seu entendimento prático.
+Se surgirem problemas durante os testes, consulte a seção [Dúvidas Frequentes](../09_duvidas_frequentes.md) para possíveis soluções.
 
 No próximo tópico, veremos como usar o PraisonAI de forma "No-Code" ou "Low-Code" através de arquivos de configuração YAML.

--- a/docs/pt-br/03_usando_praisonai/04_criando_seu_primeiro_agente.md
+++ b/docs/pt-br/03_usando_praisonai/04_criando_seu_primeiro_agente.md
@@ -1,0 +1,58 @@
+# Criando Seu Primeiro Agente
+
+Este guia prático mostra passo a passo como colocar um agente PraisonAI em funcionamento usando Python. Se você já instalou o pacote `praisonaiagents`, siga em frente.
+
+## 1. Configure o Ambiente
+
+1. Abra um terminal e crie uma pasta para seus testes:
+   ```bash
+   mkdir meu_primeiro_agente
+   cd meu_primeiro_agente
+   ```
+2. (Opcional) Crie e ative um ambiente virtual:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # No Windows use `.venv\Scripts\activate`
+   ```
+3. Instale o pacote se ainda não o fez:
+   ```bash
+   pip install praisonaiagents
+   ```
+
+## 2. Escreva o Código do Agente
+
+Crie um arquivo `roteirista.py` com o seguinte conteúdo:
+
+```python
+from praisonaiagents import Agent
+
+agente = Agent(
+    instructions="Você é um roteirista de cinema muito criativo.",
+    role="Roteirista",
+    goal="Escrever um pequeno roteiro sobre robôs em Marte."
+)
+
+resultado = agente.start("Crie o roteiro com três cenas principais.")
+print(resultado)
+```
+
+## 3. Execute e Analise
+
+No terminal, rode:
+```bash
+python roteirista.py
+```
+
+O PraisonAI conectará ao modelo LLM configurado (por padrão OpenAI) e exibirá o roteiro gerado.
+
+- Se estiver tudo certo, experimente alterar as instruções, o papel ou o objetivo e observe como o resultado muda.
+- Consulte [Usando o PraisonAI com Python](01_usando_com_python.md) para entender todos os parâmetros disponíveis.
+
+## 4. Próximos Passos
+
+Depois de dominar este exemplo simples, explore:
+- [Criando múltiplos agentes](01_usando_com_python.md#criando-múltiplos-agentes-multi-agents)
+- [Definindo agentes via YAML](02_usando_com_yaml.md)
+- Os notebooks em `examples/python/` para casos de uso completos.
+
+Bom aprendizado!

--- a/docs/pt-br/03_usando_praisonai/05_modelos_de_agentes.md
+++ b/docs/pt-br/03_usando_praisonai/05_modelos_de_agentes.md
@@ -1,0 +1,137 @@
+# Modelos de Agentes Disponíveis
+
+Esta seção apresenta um resumo dos modelos de agentes fornecidos como exemplos no PraisonAI. Eles servem como ponto de partida para criar soluções adaptadas às suas necessidades.
+
+Cada agente abaixo possui um script dedicado em `examples/python/agents/`. A execução parte do mesmo princípio: instale o pacote `praisonaiagents`, configure sua chave de API do modelo de linguagem e rode o arquivo Python correspondente.
+
+## Agentes Especializados
+
+### 1. Agente Analista de Dados
+Arquivo: `data-analyst-agent.py`
+
+Utiliza ferramentas de manipulação de CSV/Excel para ler, filtrar, agrupar e gerar insights de dados.
+Execute:
+```bash
+python data-analyst-agent.py
+```
+
+### 2. Agente Financeiro
+Arquivo: `finance-agent.py`
+
+Consulta preços, informações e histórico de ações. Útil para análises de mercado básicas.
+```bash
+python finance-agent.py
+```
+
+### 3. Agente de Pesquisa
+Arquivo: `research-agent.py`
+
+Realiza buscas na web com `duckduckgo` e retorna resultados resumidos.
+```bash
+python research-agent.py
+```
+
+### 4. Agente de Planejamento
+Arquivo: `planning-agent.py`
+
+Ajuda a planejar viagens ou atividades pesquisando informações relevantes on-line.
+```bash
+python planning-agent.py
+```
+
+### 5. Agente de Recomendação
+Arquivo: `recommendation-agent.py`
+
+Gera recomendações (como filmes) a partir de buscas na web e de conhecimento prévio do LLM.
+```bash
+python recommendation-agent.py
+```
+
+### 6. Agente de Compras
+Arquivo: `shopping-agent.py`
+
+Pesquisa produtos em diferentes sites e organiza os preços em formato de tabela.
+```bash
+python shopping-agent.py
+```
+
+### 7. Agente de Programação
+Arquivo: `programming-agent.py`
+
+Contém ferramentas para execução de código, análise, formatação e acesso ao shell. Permite iterar no desenvolvimento de scripts.
+```bash
+python programming-agent.py
+```
+
+### 8. Agente de Markdown
+Arquivo: `markdown-agent.py`
+
+Gera ou transforma textos em Markdown.
+```bash
+python markdown-agent.py
+```
+
+### 9. Agente de Busca na Web
+Arquivo: `websearch-agent.py`
+
+Focado em pesquisas rápidas na internet.
+```bash
+python websearch-agent.py
+```
+
+### 10. Agente Wikipedia
+Arquivo: `wikipedia-agent.py`
+
+Consulta a Wikipedia para reunir informações detalhadas sobre um tópico.
+```bash
+python wikipedia-agent.py
+```
+
+### 11. Agente SearxNG
+Arquivo: `searxng-agent.py`
+
+Realiza buscas através de uma instância SearxNG (pode ser container Docker). Necessita do serviço rodando localmente.
+```bash
+python searxng-agent.py
+```
+
+### 12. Agente de Imagens
+Arquivo: `image-agent.py`
+
+Aplica análise de imagens, podendo lidar tanto com URLs quanto com arquivos locais.
+```bash
+python image-agent.py
+```
+
+### 13. Agente de Imagem para Texto
+Arquivo: `image-to-text-agent.py`
+
+Semelhante ao agente de imagens, mas com foco em descrever conteúdo visual (OCR/descrição). Execute:
+```bash
+python image-to-text-agent.py
+```
+
+### 14. Agente de Vídeo
+Arquivo: `video-agent.py`
+
+Permite fornecer arquivos de vídeo para extração de informações e resumo de eventos.
+```bash
+python video-agent.py
+```
+
+### 15. Agente "Single"
+Arquivo: `single-agent.py`
+
+Exemplo básico de um agente único com prompt simples. Ótimo ponto de partida.
+```bash
+python single-agent.py
+```
+
+## Dicas Gerais
+
+1. Abra um terminal na pasta `examples/python/agents`.
+2. Ative seu ambiente virtual (se usar).
+3. Execute o arquivo desejado conforme mostrado acima.
+4. Explore e modifique os scripts para entender como cada agente opera.
+
+Com essas bases, você pode combinar os agentes ou adaptá-los para criar soluções personalizadas no PraisonAI.

--- a/docs/pt-br/09_duvidas_frequentes.md
+++ b/docs/pt-br/09_duvidas_frequentes.md
@@ -1,0 +1,45 @@
+# Dúvidas Frequentes (FAQ)
+
+Esta seção reúne respostas rápidas para questões comuns ao começar com o PraisonAI.
+
+## 1. "ModuleNotFoundError: praisonaiagents"
+Se, ao executar um exemplo em Python, você receber essa mensagem:
+```bash
+ModuleNotFoundError: No module named 'praisonaiagents'
+```
+Isso indica que o pacote não está instalado no ambiente atual. Execute:
+```bash
+pip install praisonaiagents
+```
+Se estiver usando um clone do repositório, você também pode instalar em modo editável:
+```bash
+uv pip install -e .
+```
+(caso tenha o `uv` instalado) ou
+```bash
+pip install -e .
+```
+
+## 2. Como configuro minha `OPENAI_API_KEY`?
+A maioria dos exemplos utiliza modelos da OpenAI. Defina a variável de ambiente com:
+```bash
+export OPENAI_API_KEY="sua-chave-aqui"  # Linux ou macOS
+set OPENAI_API_KEY="sua-chave-aqui"      # Windows CMD
+$env:OPENAI_API_KEY="sua-chave-aqui"     # PowerShell
+```
+
+## 3. Preciso de GPU ou conexão constante com a internet?
+Para executar os agentes locais que usam modelos via API (como OpenAI), basta ter conexão com a internet. Uma GPU dedicada só é necessária se você planeja rodar modelos locais pesados (ex.: via Ollama ou outros provedores que permitam modelos offline).
+
+## 4. Onde ficam os exemplos prontos?
+Todos os scripts demonstrativos estão em `examples/python/`. A pasta é subdividida em:
+- `agents/` – agentes especializados (veja [Modelos de Agentes](03_usando_praisonai/05_modelos_de_agentes.md)).
+- `general/` – conceitos isolados como memória, ferramentas e workflows.
+- `concepts/` – implementações de RAG, processamento de CSV etc.
+- `usecases/` – estudos de caso completos.
+
+Abra um terminal nesse diretório e execute o arquivo desejado com `python nome_do_exemplo.py`.
+
+## 5. Como tiro outras dúvidas ou reporto problemas?
+Consulte o repositório no GitHub e abra uma *issue* descrevendo o problema ou a sugestão. Se preferir discutir em português, sinta-se à vontade.
+

--- a/docs/pt-br/README.md
+++ b/docs/pt-br/README.md
@@ -7,13 +7,17 @@ Navegue pelos módulos à esquerda para começar sua jornada de aprendizado.
 ## Estrutura do Curso
 
 *   **Introdução:** Visão geral do PraisonAI e desta documentação.
+*   **Metodologia de Aprendizado:** Orientações científicas para estudar com eficiência.
 *   **Instalação:** Como instalar o PraisonAI em seu ambiente.
 *   **Conceitos Fundamentais:** Os blocos de construção do PraisonAI.
 *   **Usando o PraisonAI:** Guias práticos para Python, YAML e JavaScript/TypeScript.
+*   **Guia Rápido: Criando Seu Primeiro Agente:** Passo a passo para colocar um agente em funcionamento.
+*   **Modelos de Agentes:** Visão geral dos agentes especializados disponíveis nos exemplos.
 *   **Workflows Avançados:** Explore as capacidades de múltiplos agentes.
 *   **Ferramentas:** Utilizando e criando ferramentas.
 *   **Modelos LLM:** Integrando com diversos modelos de linguagem.
 *   **Exemplos Práticos:** Estudos de caso detalhados.
 *   **Contribuindo e Desenvolvimento:** Para quem quer ir além.
+*   **Dúvidas Frequentes:** Respostas rápidas para problemas comuns.
 
 Boa sorte e bons estudos!

--- a/docs/pt-br/plan.md
+++ b/docs/pt-br/plan.md
@@ -1,0 +1,42 @@
+# Plano de Conteúdo do Curso PraisonAI
+
+Este arquivo resume os módulos já existentes na documentação em `docs/pt-br` e aponta temas que ainda podem ser desenvolvidos. Use-o como guia para acompanhar o progresso do material.
+
+## Conteúdo Atual
+
+1. **Introdução**
+   - Como usar esta documentação e plugins recomendados para Obsidian.
+   - O que é o PraisonAI, filosofia e casos de uso.
+   - Metodologia de aprendizado baseada em ciclo científico.
+2. **Instalação**
+   - Guia completo de instalação no Windows com variáveis de ambiente e verificação do pacote.
+3. **Conceitos Fundamentais**
+   - Explicação sobre agentes, tarefas, ferramentas, processos, memória e RAG.
+4. **Usando o PraisonAI**
+   - Uso com Python (`praisonaiagents`).
+   - Uso com YAML (CLI `praisonai`).
+   - Uso com JavaScript/TypeScript.
+   - Guia rápido "Criando Seu Primeiro Agente".
+   - Catálogo de modelos de agentes disponíveis nos exemplos.
+5. **Workflows Avançados**
+   - Colaboração entre agentes, roteamento, orquestração, modo autônomo, paralelização e encadeamento de prompts.
+6. **Ferramentas**
+   - Visão geral e criação de ferramentas personalizadas.
+7. **Modelos LLM**
+   - Configuração de diferentes provedores (OpenAI, Ollama, Groq, etc.).
+8. **Exemplos Práticos**
+   - Estudos de caso demonstrando aplicações reais do framework.
+9. **Contribuindo e Desenvolvimento**
+   - Passos para trabalhar localmente e contribuir com o projeto.
+10. **Dúvidas Frequentes (FAQ)**
+    - Respostas rápidas para erros comuns de instalação e execução.
+
+## Pontos a Desenvolver
+
+- Adicionar instruções de instalação para Linux e macOS.
+- Explorar exemplos mais detalhados de ferramentas e memórias avançadas.
+- Criar exercícios práticos adicionais para fixação dos conceitos.
+- Documentar integrações específicas com outros provedores de LLM (ex.: Gemini, Anthropic).
+- Incluir guia de depuração e boas práticas para resolução de problemas.
+
+Este plano deve ser atualizado sempre que novos módulos ou seções forem criados.


### PR DESCRIPTION
## Summary
- document course progress in `plan.md`
- add methodology overview and quickstart agent guide
- link PT-BR docs from the main README
- catalogue available agent examples
- fix a typo in the PT-BR agent catalogue

## Testing
- `pytest -q` *(fails: No module named 'praisonaiagents')*

------
https://chatgpt.com/codex/tasks/task_e_68433360adac8327a7479f2b0ae011a7