### PR TITLE
Fix test import handling

### DIFF
--- a/src/praisonai/tests/unit/agent/test_mini_agents_fix.py
+++ b/src/praisonai/tests/unit/agent/test_mini_agents_fix.py
@@ -6,14 +6,12 @@ This tests the core functionality without external dependencies.
 
 import sys
 import os
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
 
-try:
-    from praisonaiagents import Agent, Agents
-    print("✅ Successfully imported PraisonAI Agents")
-except ImportError as e:
-    print(f"❌ Failed to import: {e}")
-    sys.exit(1)
+pytest.importorskip("praisonaiagents")
+from praisonaiagents import Agent, Agents
 
 def test_context_processing():
     """Test the context processing logic without running actual agents"""


### PR DESCRIPTION
### **User description**
## Summary
- avoid failing when `praisonaiagents` isn't installed in test_mini_agents_fix

## Testing
- `pytest src/praisonai/tests/unit/agent/test_mini_agents_fix.py -q`
- `pytest -q` *(fails: 12 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68433214df3c83278999e7a3b4d2720c


___

### **PR Type**
Tests


___

### **Description**
- Refactored test to skip if `praisonaiagents` is missing

- Removed manual import error handling and exit

- Ensured cleaner test execution with `pytest.importorskip`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_mini_agents_fix.py</strong><dd><code>Use pytest.importorskip for conditional test execution</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/praisonai/tests/unit/agent/test_mini_agents_fix.py

<li>Replaced manual import error handling with <code>pytest.importorskip</code><br> <li> Removed print statements and sys.exit on import failure<br> <li> Ensured test is skipped gracefully if dependency is missing


</details>


  </td>
  <td><a href="https://github.com/Habdel-Edenfield/PraisonAI/pull/13/files#diff-b3d87d9676fe3be7dae60a811091562c87fc52c2457b0528f9371c8fe107af79">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>